### PR TITLE
Add civitai integration and face grouping nodes

### DIFF
--- a/DIFF_20250627_155335.md
+++ b/DIFF_20250627_155335.md
@@ -1,0 +1,7 @@
+# Diff for commit on 2025-06-27 15:53 UTC
+
+- Added `custom_nodes/CivitaiNodes` package with nodes:
+  - `CivitaiModelDownloader` for downloading models via the civitai Python SDK.
+  - `FaceGrouping` to group images by detected face encodings.
+  - `FaceSwapVideo` placeholder for swapping faces in videos.
+- Registered new nodes through package `custom_nodes/CivitaiNodes`.

--- a/RECOMMENDATIONS_20250627_155335.md
+++ b/RECOMMENDATIONS_20250627_155335.md
@@ -1,0 +1,4 @@
+# Recommendations logged on 2025-06-27 15:53 UTC
+
+- Consider providing proper implementations for video face swapping and facial recognition. Current nodes are placeholders due to missing dependencies.
+- Document dependency installation for `civitai` and optional `face_recognition` for new nodes.

--- a/custom_nodes/CivitaiNodes/__init__.py
+++ b/custom_nodes/CivitaiNodes/__init__.py
@@ -1,0 +1,7 @@
+from .civitai_nodes import NODE_CLASS_MAPPINGS as CIVITAI_NODES
+from .face_grouping import NODE_CLASS_MAPPINGS as FACE_GROUP_NODES
+from .face_swap_video import NODE_CLASS_MAPPINGS as FACE_SWAP_VIDEO_NODES
+
+NODE_CLASS_MAPPINGS = {}
+for d in (CIVITAI_NODES, FACE_GROUP_NODES, FACE_SWAP_VIDEO_NODES):
+    NODE_CLASS_MAPPINGS.update(d)

--- a/custom_nodes/CivitaiNodes/civitai_nodes.py
+++ b/custom_nodes/CivitaiNodes/civitai_nodes.py
@@ -1,0 +1,47 @@
+import os
+import requests
+from typing import Tuple
+
+try:
+    from civitai import models as civitai_models
+except Exception as e:
+    civitai_models = None
+
+class CivitaiModelDownloader:
+    """Download models from Civitai by query."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "query": ("STRING", {"default": ""}),
+                "save_directory": ("STRING", {"default": "models"})
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "download"
+    CATEGORY = "Civitai"
+
+    def download(self, query: str, save_directory: str) -> Tuple[str]:
+        if civitai_models is None:
+            raise RuntimeError("civitai package not installed")
+        resp = civitai_models.get(limit=1, query=query)
+        if not resp.items:
+            raise RuntimeError("No models found for query")
+        model = resp.items[0]
+        version = model.modelVersions[0]
+        url = version.downloadUrl
+        os.makedirs(save_directory, exist_ok=True)
+        filename = os.path.join(save_directory, os.path.basename(url))
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(filename, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+        return (filename,)
+
+NODE_CLASS_MAPPINGS = {
+    "CivitaiModelDownloader": CivitaiModelDownloader,
+}

--- a/custom_nodes/CivitaiNodes/face_grouping.py
+++ b/custom_nodes/CivitaiNodes/face_grouping.py
@@ -1,0 +1,54 @@
+import os
+from typing import List, Tuple
+
+try:
+    import face_recognition
+except Exception:
+    face_recognition = None
+from PIL import Image
+import numpy as np
+
+class FaceGrouping:
+    """Group images by detected faces."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "images": ("IMAGE", {"forceInput": True}),
+                "distance_threshold": ("FLOAT", {"default": 0.6, "min": 0.1, "max": 1.0, "step": 0.05})
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "group"
+    CATEGORY = "Face"
+
+    def group(self, images: List[Image.Image], distance_threshold: float) -> Tuple[str]:
+        if face_recognition is None:
+            raise RuntimeError("face_recognition package not installed")
+        groups = {}
+        encodings = []
+        for idx, img in enumerate(images):
+            arr = np.array(img.convert("RGB"))
+            enc = face_recognition.face_encodings(arr)
+            if not enc:
+                continue
+            encodings.append((idx, enc[0]))
+        for idx, encoding in encodings:
+            placed = False
+            for gid, group in groups.items():
+                if any(face_recognition.face_distance([e], encoding)[0] < distance_threshold for e in group['encodings']):
+                    group['indices'].append(idx)
+                    group['encodings'].append(encoding)
+                    placed = True
+                    break
+            if not placed:
+                gid = len(groups)
+                groups[gid] = {'indices': [idx], 'encodings': [encoding]}
+        result = {gid: g['indices'] for gid, g in groups.items()}
+        return (str(result),)
+
+NODE_CLASS_MAPPINGS = {
+    "FaceGrouping": FaceGrouping,
+}

--- a/custom_nodes/CivitaiNodes/face_swap_video.py
+++ b/custom_nodes/CivitaiNodes/face_swap_video.py
@@ -1,0 +1,53 @@
+import os
+from typing import Tuple
+
+try:
+    import cv2
+except Exception:
+    cv2 = None
+
+class FaceSwapVideo:
+    """Placeholder node for face swap in video."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "source_video": ("STRING", {"default": ""}),
+                "target_video": ("STRING", {"default": ""}),
+                "output_path": ("STRING", {"default": "output.mp4"}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "swap_video"
+    CATEGORY = "Face"
+
+    def swap_video(self, source_video: str, target_video: str, output_path: str) -> Tuple[str]:
+        if cv2 is None:
+            raise RuntimeError("OpenCV not installed")
+        # Placeholder: actual face swap algorithm required
+        cap_src = cv2.VideoCapture(source_video)
+        cap_tgt = cv2.VideoCapture(target_video)
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        out = cv2.VideoWriter(output_path, fourcc, 30.0, (int(cap_tgt.get(3)), int(cap_tgt.get(4))))
+        while cap_tgt.isOpened() and cap_src.isOpened():
+            ret_t, frame_t = cap_tgt.read()
+            ret_s, frame_s = cap_src.read()
+            if not ret_t or not ret_s:
+                break
+            # naive copy of source onto target center
+            x = frame_t.shape[1]//4
+            y = frame_t.shape[0]//4
+            h, w = frame_s.shape[0]//2, frame_s.shape[1]//2
+            face = cv2.resize(frame_s[0:h,0:w], (w, h))
+            frame_t[y:y+h, x:x+w] = face
+            out.write(frame_t)
+        cap_src.release()
+        cap_tgt.release()
+        out.release()
+        return (output_path,)
+
+NODE_CLASS_MAPPINGS = {
+    "FaceSwapVideo": FaceSwapVideo,
+}


### PR DESCRIPTION
## Summary
- create custom_nodes/CivitaiNodes package
- add CivitaiModelDownloader to fetch models from civitai
- add FaceGrouping node for grouping faces with face_recognition
- add FaceSwapVideo placeholder node for video processing
- log changes in DIFF_20250627_155335.md
- add new recommendations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685ebdac3f7c832a97f0946c73593e7d

## Summary by Sourcery

Introduce a new custom_nodes/CivitaiNodes package providing nodes for downloading Civitai models, grouping faces in images, and a placeholder video face swap node.

New Features:
- Add CivitaiModelDownloader node to fetch models via the Civitai SDK
- Add FaceGrouping node to cluster images by detected facial encodings
- Add FaceSwapVideo placeholder node for video face swapping

Documentation:
- Add DIFF_20250627_155335.md and RECOMMENDATIONS_20250627_155335.md to log changes and outline dependency setup

Chores:
- Register new nodes in custom_nodes/CivitaiNodes/__init__.py